### PR TITLE
feat: integrate GStreamer core and plugins into Yocto image (issue #7)

### DIFF
--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -11,4 +11,5 @@ BBLAYERS ?= " \
   /home/giovanni/courses/final-project-vannidelprete/poky/meta-yocto-bsp \
   /home/giovanni/courses/final-project-vannidelprete/meta-streaming \
   /home/giovanni/courses/final-project-vannidelprete/meta-openembedded/meta-oe \
+  /home/giovanni/courses/final-project-vannidelprete/meta-openembedded/meta-multimedia \
   "

--- a/meta-streaming/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-streaming/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,9 @@
+IMAGE_INSTALL:append = " kernel-modules"
+
+# Issue #7: GStreamer core and plugins for V4L2 multimedia pipeline
+IMAGE_INSTALL:append = " \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    "


### PR DESCRIPTION
## Summary

- Add `meta-openembedded/meta-multimedia` layer to `bblayers.conf`
- Add `gstreamer1.0`, `gstreamer1.0-plugins-base`, `gstreamer1.0-plugins-good`, `gstreamer1.0-plugins-bad` to `IMAGE_INSTALL` via `core-image-minimal.bbappend` in `meta-streaming`

## Test plan

- [ ] Image builds without errors (`bitbake core-image-minimal`)
- [ ] After boot, `gst-launch-1.0 --version` runs successfully inside QEMU

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)