### PR TITLE
feat: add pipeline verification script and recipe (issue #9)

### DIFF
--- a/meta-streaming/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-streaming/recipes-core/images/core-image-minimal.bbappend
@@ -10,3 +10,6 @@ IMAGE_INSTALL:append = " \
 
 # Issue #8: RTSP server library for streaming pipeline
 IMAGE_INSTALL:append = " gstreamer1.0-rtsp-server"
+
+# Issue #9: pipeline verification script
+IMAGE_INSTALL:append = " pipeline-test"

--- a/meta-streaming/recipes-multimedia/pipeline-test/files/verify-pipeline.sh
+++ b/meta-streaming/recipes-multimedia/pipeline-test/files/verify-pipeline.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# verify-pipeline.sh — Smoke test for V4L2 → GStreamer pipeline (issue #9)
+
+PASS=0
+FAIL=1
+
+check() {
+    if [ $1 -eq 0 ]; then
+        echo "[PASS] $2"
+    else
+        echo "[FAIL] $2"
+        exit $FAIL
+    fi
+}
+
+echo "=== V4L2 → GStreamer pipeline verification ==="
+
+# Step 1: load vivid module
+echo ""
+echo "--- Step 1: loading vivid module ---"
+modprobe vivid
+check $? "modprobe vivid"
+
+# Step 2: check /dev/video0 is present
+echo ""
+echo "--- Step 2: checking /dev/video0 ---"
+[ -e /dev/video0 ]
+check $? "/dev/video0 present"
+
+# Step 3: basic pipeline with fakesink (5 seconds)
+echo ""
+echo "--- Step 3: v4l2src ! fakesink (5 s) ---"
+timeout 5 gst-launch-1.0 -q v4l2src device=/dev/video0 num-buffers=30 ! fakesink sync=false
+check $? "gst-launch-1.0 v4l2src ! fakesink"
+
+# Step 4: pipeline with videoconvert (optional, graceful failure)
+echo ""
+echo "--- Step 4: v4l2src ! videoconvert ! fakesink (optional) ---"
+timeout 5 gst-launch-1.0 -q v4l2src device=/dev/video0 num-buffers=30 ! videoconvert ! fakesink sync=false
+if [ $? -eq 0 ]; then
+    echo "[PASS] v4l2src ! videoconvert ! fakesink"
+else
+    echo "[SKIP] videoconvert step failed (non-fatal)"
+fi
+
+echo ""
+echo "=== All required checks passed ==="

--- a/meta-streaming/recipes-multimedia/pipeline-test/pipeline-test_1.0.bb
+++ b/meta-streaming/recipes-multimedia/pipeline-test/pipeline-test_1.0.bb
@@ -1,0 +1,16 @@
+SUMMARY = "V4L2 to GStreamer pipeline verification script"
+DESCRIPTION = "Installs verify-pipeline.sh to smoke-test the vivid V4L2 device \
+and GStreamer pipeline inside QEMU (issue #9)."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://verify-pipeline.sh"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/verify-pipeline.sh ${D}${bindir}/verify-pipeline.sh
+}
+
+FILES:${PN} = "${bindir}/verify-pipeline.sh"


### PR DESCRIPTION
## Summary

- Add `meta-streaming/recipes-multimedia/pipeline-test/pipeline-test_1.0.bb` — recipe that installs `verify-pipeline.sh` to `/usr/bin/` inside the image
- `verify-pipeline.sh` automatizza lo smoke test della pipeline V4L2 → GStreamer:
  1. `modprobe vivid` → carica il driver virtuale
  2. Verifica presenza di `/dev/video0`
  3. `gst-launch-1.0 v4l2src device=/dev/video0 num-buffers=30 ! fakesink`
  4. Step opzionale con `videoconvert` (non bloccante)
- Add `pipeline-test` to `IMAGE_INSTALL` via `core-image-minimal.bbappend`

## Test plan

- [ ] Image builds without errors (`bitbake core-image-minimal`)
- [ ] Boot QEMU: `runqemu qemuarm64`
- [ ] Inside QEMU: `verify-pipeline.sh` → tutti i check `[PASS]`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)